### PR TITLE
Update temporal-interpretation.adoc

### DIFF
--- a/en/data-processing/modules/ROOT/pages/temporal-interpretation.adoc
+++ b/en/data-processing/modules/ROOT/pages/temporal-interpretation.adoc
@@ -147,8 +147,8 @@ Occurrences are returned by the search and download APIs if the occurrence date/
 | Search eventDate=2023-01-11            |                         included | _excluded_ |    _excluded_ | _excluded_ | Search for "on 11 January 2023"
 | Search eventDate=2023-01-11,2023-01-12 |                         included | _excluded_ |      included | _excluded_ | Search for "from the start of 11 January 2023 until the end of 12 January 2023"
 | Search eventDate=*,2023-01             |                         included |   included |      included | _excluded_ | Search for "before end of January 2023"
-| Search eventDate=2023-01,2023-01       |                         included |   included |      included | _excluded_ | Search for "after start of January 2023 and before end of January 2023"
-| Search eventDate=2023-01               |                         included |   included |      included | _excluded_ | Search for "after start of January 2023 and before end of January 2023"
+| Search eventDate=2023-01,2023-01       |                         included |   excluded |      included | _excluded_ | Search for "after start of January 2023 and before end of January 2023"
+| Search eventDate=2023-01               |                         included |   excluded |      included | _excluded_ | Search for "after start of January 2023 and before end of January 2023"
 |===
 
 This implementation avoids returning occurrences with eventDates like "2000/2021" in many queries. (There are millions of occurrences with large ranges like this.)


### PR DESCRIPTION
These records would be excluded from a search in 2023 (since the record has a value in 2021).

I am unsure if the record date should have been `2023-01` so this suggestion is based on the value being correct